### PR TITLE
Allow multiple-word overrides

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -46,7 +46,6 @@ def replace_words(words, count):
     while i < len(words) - count + 1:
         phrase = words[i : i + count]
         key = " ".join(phrase)
-        print("Key: ", key)
         if key in mapping:
             new_words.append(mapping[key])
             i = i + count

--- a/utils.py
+++ b/utils.py
@@ -50,7 +50,6 @@ def replace_words(words, count):
             new_words.append(mapping[key])
             i = i + count
         else:
-            print(phrase)
             new_words.append(phrase[0])
             i = i + 1
 
@@ -62,7 +61,6 @@ def parse_words(m):
     words = list(map(parse_word, m.dgndictation.words))
     for i in range(1, 4):
         words = replace_words(words, i)
-        print(words)
 
     return words
 

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,11 @@
-from talon.voice import Str, press
+import json
+
 import talon.clip as clip
 from talon import resource
+from talon.voice import Str, press
+from time import sleep
+
 from .bundle_groups import FILETYPE_SENSITIVE_BUNDLES
-import json
 
 # overrides are used as a last resort to override the output. Some uses:
 # - frequently misheard words
@@ -34,8 +37,35 @@ def join_words(words, sep=" "):
     return out
 
 
+def replace_words(words, count):
+    if len(words) < count:
+        return words
+
+    new_words = []
+    i = 0
+    while i < len(words) - count + 1:
+        phrase = words[i : i + count]
+        key = " ".join(phrase)
+        print("Key: ", key)
+        if key in mapping:
+            new_words.append(mapping[key])
+            i = i + count
+        else:
+            print(phrase)
+            new_words.append(phrase[0])
+            i = i + 1
+
+    new_words.extend(words[i:])
+    return new_words
+
+
 def parse_words(m):
-    return list(map(parse_word, m.dgndictation.words))
+    words = list(map(parse_word, m.dgndictation.words))
+    for i in range(1, 4):
+        words = replace_words(words, i)
+        print(words)
+
+    return words
 
 
 def insert(s):


### PR DESCRIPTION
In the talon beta, the included `utils.py` file only allows using one-word replacements at a time. Since this is a part of the starter pack, it seems like this is a good ability to include.