### PR TITLE
make @say less greedy

### DIFF
--- a/text/formatters.py
+++ b/text/formatters.py
@@ -59,7 +59,7 @@ keymap = {}
 keymap.update(
     {
         "phrase <dgndictation> [over]": text,
-        "(say | speak) <dgndictation>++ [over]": text,
+        "(say | speak) <dgndictation>+ [over]": text,
         "sentence <dgndictation> [over]": sentence_text,
         "word <dgnwords>": word,
         "(%s)+ <dgndictation> [over]" % (" | ".join(formatters)): FormatText,


### PR DESCRIPTION
fixes "say java space dash version" to correctly
output `java -version` instead of `java @space @dash version`